### PR TITLE
added note on required 'unzip' command in data/README.md

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -3,7 +3,7 @@
 You need the following files to run the example scripts.
 All files should be saved in this directory.
 You can download them at [Deep Image Reconstruction@figshare](https://figshare.com/articles/Deep_Image_Reconstruction/7033577).
-The script, `downloaddata.sh`, will download all required data for the example code.
+The script, `downloaddata.sh`, will download all required data for the example code. The script requires the `unzip` command (for Ubuntu `apt install unzip`).
 
 - estimated_vgg19_cnn_feat_std.mat
 - estimated_vgg19LeakyReluAvePool_cnn_feat_std.mat


### PR DESCRIPTION
This is just for clarifying documentation since unzip was not out of the box in Ubuntu 20.04.